### PR TITLE
change trip_confirm translation MODE PURPOSE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Add any directories, files, or patterns you don't want to be tracked by version control
+
+# macOS
+.DS_Store
+**/.DS_Store
+
+# Windows
+Thumbs.db
+**/Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# e-mission-translate
-Translation files for e-mission-phone
+# tracemob-phone-translate
+Translation files for tracemob-phone
 
 | Translated file | Original `en` version with keys |
 | ----------------| --------------------------------|
 | `DCLocalizable.strings` | [e-mission-data-collection-repo](https://github.com/e-mission/e-mission-data-collection/), `res/ios/en.lproj` |
-| `i18n/*.json` | [e-mission-phone repo](https://github.com/e-mission/e-mission-phone/), `www/i18n/` |
-| `i18n/intro/*.json` | [e-mission-phone repo](https://github.com/e-mission/e-mission-phone/), `www/templates/intro/` |
+| `i18n/*.json` | [tracemob-phone repo](https://github.com/fabmob/tracemob-phone), `www/i18n/` |
+| `i18n/intro/*.json` | [tracemob-phone repo](https://github.com/fabmob/tracemob-phone), `www/templates/intro/` |
 | `dc_strings.xml` | [e-mission-data-collection-repo](https://github.com/e-mission/e-mission-data-collection/), `res/android/values` |

--- a/fr/i18n/intro/login-fr.html
+++ b/fr/i18n/intro/login-fr.html
@@ -4,7 +4,7 @@
 <div>
 Parlez-vouz français? Écrir cette page en français SVP!
 </div>
-<center><h3>Login via google</h3></center></div>
+<center><h3>Se connecter via Token</h3></center></div>
 
 <div class="intro-text">
 Currently, we only support logging in via google, since they support techniques
@@ -12,7 +12,7 @@ such as two factor authentication for greater security. Participants at UC
 Berkeley can choose to login using either their CalNet ID or a personal gmail
 account.
 <div class="intro-space"></div>
-<button class="button button-block button-balanced" ng-click="login()">Login via Google</button>
+<button class="button button-block button-balanced" ng-click="login()">Se connecter via Token</button>
 </div>
 
 

--- a/fr/i18n/trip_confirm_options-fr.json
+++ b/fr/i18n/trip_confirm_options-fr.json
@@ -1,5 +1,5 @@
 {
-    "modeOptions" : [
+    "MODE" : [
          {"text":"Marche", "value":"walk"},
          {"text":"Vélo","value":"bike"},
          {"text":"Voiture solo","value":"drove_alone"},
@@ -11,7 +11,7 @@
          {"text":"Tram","value":"tramway"},
          {"text":"Navette","value":"free_shuttle"},
          {"text":"Autre","value":"other_mode"}],
-      "purposeOptions" : [
+      "PURPOSE" : [
          {"text":"Domicile", "value":"home"},
          {"text":"Travail","value":"work"},
          {"text":"École","value":"school"},
@@ -24,4 +24,4 @@
          {"text":"Loisir","value":"entertainment"},
          {"text":"Autre","value":"other_purpose"}]
   }
-  
+

--- a/it/i18n/trip_confirm_options-it.json
+++ b/it/i18n/trip_confirm_options-it.json
@@ -1,5 +1,5 @@
 {
-    "modeOptions" : [
+    "MODE" : [
          {"text":"A piedi", "value":"walk"},
          {"text":"Bici","value":"bike"},
          {"text":"In macchina da solo","value":"drove_alone"},
@@ -9,7 +9,7 @@
          {"text":"Treno","value":"train"},
          {"text":"Navetta","value":"free_shuttle"},
          {"text":"Altro","value":"other_mode"}],
-      "purposeOptions" : [
+      "PURPOSE" : [
          {"text":"Casa", "value":"home"},
          {"text":"Lavoro","value":"work"},
          {"text":"Scuola","value":"school"},
@@ -22,4 +22,3 @@
          {"text":"Divertimento","value":"entertainment"},
          {"text":"Altro","value":"other_purpose"}]
   }
-  


### PR DESCRIPTION
Hi !
 in a recent commit https://github.com/e-mission/e-mission-phone/commit/55372780ced0f9b6a0ce1b4fdbd9fee57ca765d7 you have changed the name for "MODE" and "PURPOSE" translation labels in the phone code but not in the e-mission-translate files, so Yann and I propose you to correct this.
Only 2 json files concerned in this PR : trip_confirm_options-fr and it