### PR TITLE
Added spanish translations to purpose dropdown text

### DIFF
--- a/es/i18n/trip_confirm_options-es.json
+++ b/es/i18n/trip_confirm_options-es.json
@@ -22,12 +22,12 @@
        {"text":"Transbordo", "value":"transit_transfer"},
        {"text":"Compras","value":"shopping"},
        {"text":"Comida","value":"meal"},
-       {"text":"Recoger/Entregar 👤","value":"pick_drop_person"},
-       {"text":"Recoger/Entregar 📦","value":"pick_drop_item"},
-       {"text":"Personal/Médico","value":"personal_med"},
+       {"text":"Recoger/ Entregar Individuo","value":"pick_drop_person"},
+       {"text":"Recoger/ Entregar Objeto","value":"pick_drop_item"},
+       {"text":"Personal/ Médico","value":"personal_med"},
        {"text":"Acceder a Recreación","value":"access_recreation"},
-       {"text":"Recreación/Ejercicio","value":"exercise"},
-       {"text":"Entretenimiento/Social","value":"entertainment"},
+       {"text":"Recreación/ Ejercicio","value":"exercise"},
+       {"text":"Entretenimiento/ Social","value":"entertainment"},
        {"text":"Religioso", "value":"religious"},
        {"text":"Otros","value":"other"}]
 }

--- a/it/i18n/trip_confirm_options-it.json
+++ b/it/i18n/trip_confirm_options-it.json
@@ -16,9 +16,9 @@
          {"text":"Cambio mezzo", "value":"transit_transfer"},
          {"text":"Shopping","value":"shopping"},
          {"text":"Pasto","value":"meal"},
-         {"text":"Carico/scarico","value":"pick_drop"},
+         {"text":"Carico/ scarico","value":"pick_drop"},
          {"text":"Personale","value":"personal_med"},
-         {"text":"Svago/Sport","value":"exercise"},
+         {"text":"Svago/ Sport","value":"exercise"},
          {"text":"Divertimento","value":"entertainment"},
          {"text":"Altro","value":"other_purpose"}]
   }


### PR DESCRIPTION
In regards to the text changes found in: https://github.com/e-mission/e-mission-phone/pull/893#pullrequestreview-1150322180

I made sure that the following was true for the other non-english translations of the trip_confirm_options-es.json files:

- Spaces after "/" so that the mutli-line works
- Replaced emojis with the words for "pickup/drop-off" -> "item" and "person"