### PR TITLE
Dev zone keys

### DIFF
--- a/es/i18n/es.json
+++ b/es/i18n/es.json
@@ -36,7 +36,9 @@
         "nuke-all": "Eliminar todos los búferes y caché",
         "test-notification": "Probar notificación local",
         "check-log": "Verificar registro",
+        "log-title": "registro",
         "check-sensed-data": "Verificar los datos detectados",
+        "sensed-title": "Datos Detectados: Transiciones",
         "collection": "Colección",
         "sync": "Sincronizar",
         "button-accept": "Accepto",
@@ -359,7 +361,9 @@
     "errors": {
         "while-populating-composite": "Error al completar viajes compuestos",
         "while-loading-another-week": "Error al cargar viajes de {{when}} semana",
-        "while-loading-specific-week": "Error al cargar viajes para la semana de {{day}}"
+        "while-loading-specific-week": "Error al cargar viajes para la semana de {{day}}",
+        "while-log-messages": "Mientras recibo mensajes del registro ",
+        "while-max-index" : "Mientras obtengo el índice máximo "
       },
     "consent-text": {
         "title":"POLÍTICA DE PRIVACIDAD/TÉRMINOS DE USO DE NREL OPENPATH",

--- a/lo/i18n/lo.json
+++ b/lo/i18n/lo.json
@@ -36,7 +36,9 @@
         "nuke-all": "Nuke all buffers ແລະ cache",
         "test-notification": "ທົດສອບການແຈ້ງເຕືອນທ້ອງຖິ່ນ",
         "check-log": "ກວດຄືນການບັນທຶກ",
+        "log-title": "ບັນທຶກ",
         "check-sensed-data": "ກວດຄືນຂໍ້ມູນ",
+        "sensed-title":"ຂໍ້ມູນຄວາມຮູ້ສຶກ: ການຫັນປ່ຽນ",
         "collection": "ການເກັບກໍາ",
         "sync": "Sync ການປະມວນຜົນຂໍ້ມູນໃນຕົວລະບົບ",
         "button-accept": "ຂ້ອຍຍອມຮັບ",
@@ -360,7 +362,9 @@
     "errors": {
         "while-populating-composite": "ເກີດຄວາມຜິດພາດໃນລະຫວ່າງການເພີ່ມຂໍ້ມູນການເດີນທາງແບບປະສົມ",
         "while-loading-another-week": "ເກີດຄວາມຜິດພາດໃນລະຫວ່າງການໂຫຼດການເດີນທາງຂອງ {{when}} ອາທິດ",
-        "while-loading-specific-week": "ເກີດຄວາມຜິດພາດໃນລະຫວ່າງການໂຫຼດການເດີນທາງໃນອາທິດຂອງ {{day}}"
+        "while-loading-specific-week": "ເກີດຄວາມຜິດພາດໃນລະຫວ່າງການໂຫຼດການເດີນທາງໃນອາທິດຂອງ {{day}}",
+        "while-log-messages": "ໃນຂະນະທີ່ໄດ້ຮັບຂໍ້ຄວາມຈາກບັນທຶກ ",
+        "while-max-index" : "ໃນຂະນະທີ່ໄດ້ຮັບດັດຊະນີສູງສຸດ "
       },
     "consent-text": {
         "title":"ນະໂຍບາຍຄວາມເປັນສ່ວນຕົວ/ເງື່ອນໄຂການໃຊ້ງານ NREL OPENPATH",


### PR DESCRIPTION
Adding i18n to the "log" and "sensed" pages accessed from the developer zone as a part of converting them to React. While developers will likely know English since all of our documentation is only in English, translating the UI in developer zone will facilitate debugging with users who might be using the app in a language other than English.